### PR TITLE
Add Dockerfile for working in a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.lein-failures
+.lein-repl-history
+scratch
+target

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .lein-failures
 .lein-repl-history
+.lein_profiles.clj
 pom.xml
 scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM goodguide/base-oracle-java:8
+
+# Set up Leiningen
+ENV LEIN_ROOT ok
+ENV LEIN_HOME /root/.lein
+RUN mkdir $LEIN_HOME
+ADD https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein /usr/bin/lein
+RUN chmod +x /usr/bin/lein
+# Init lein and ensure it's working before continuing
+RUN lein version
+
+RUN mkdir /build
+WORKDIR /build
+
+# Set up a copy or link to your ~/.lein/profiles.clj with your Datomic creds, in this tree, so Docker can install that in the image to allow downloading Datomic
+ADD .lein_profiles.clj /root/.lein/profiles.clj
+
+# Add project.clj and install deps
+ADD project.clj /build/
+RUN lein deps
+
+# Then add the rest of the tree. (2-step approach helps avoid superflous deps building)
+ADD . /build/
+RUN lein do jar, install

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
+  :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"}}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.datomic/datomic-pro "[0.9,1.0)"]
+                 [com.datomic/datomic-pro "0.9.4815.12"]
                  [org.clojure/test.check "0.5.7"]]
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[org.clojure/tools.namespace "0.2.4"]


### PR DESCRIPTION
My intention here is to allow anyone with a My Datomic login to build a datomizer jar in a Docker container.

### example usage

After setting up the `./.lein_profiles.clj` file in the local tree, as described below, build the image using:

```bash
$ docker build -t goodguide/datomizer .
Sending build context to Docker daemon  93.7 kB
Sending build context to Docker daemon
Step 0 : FROM goodguide/base-oracle-java:8
...
Step 13 : RUN lein do jar, install
 ---> Running in ad681253d818
Created /build/target/datomizer-0.2.0.jar
Created /build/target/datomizer-0.2.0.jar
Wrote /build/pom.xml
Installed jar and pom into local repo.
 ---> 7063cc5f10fb
Removing intermediate container ad681253d818
Successfully built 7063cc5f10fb
```

The new image has a `target/datomizer-0.2.0.jar` embedded, so one could pull that out directly:

```bash
$ docker run --rm goodguide/datomizer cat target/datomizer-0.2.0.jar > target/datomizer-0.2.0.jar
```

But, a more likely workflow is to build with updated code, so run and mount the local tree:

```bash
$ docker run --rm -v `pwd`:/build/ goodguide/datomizer lein jar
```

A local `target/datomizer-0.2.0.jar` now exists, built from local tree, but built inside a Docker container.

Note that, to simplify getting the Datomic peer library in the Docker image, I chose to add Datomic's repo to the project.clj config, which requires that we explicitly define a version dependency for it to fetch. This approach is far nicer, anyway, IMO. Just let Leiningen fetch Datomic as well as Clojure and all the rest.

It also requires setting up credentials with Leiningen. Note that the approach I'm taking here is totally up for discussion, but I wanted to keep it simple while allowing for the Datomic installation to occur during Docker-build. The idea is that you'll follow the ["Full Disk Encryption" option mentioned in Leiningen's DEPLOY doc][lein-deploy], to set up an `:auth` profile:

```clojure
;; ./.lein_profiles.clj
{:auth {:repository-auth {#"my\.datomic\.com" {:username "..."
                                               :password "..."}}}}
```

This will then be installed as `/root/.lein/profiles.clj` in the Docker image on build, so your credentials are available to lein later during the `lein deps` command. (The username/password here are the same you see at <https://my.datomic.com/account>, not necessarily your login credentials.)

[lein-deploy]: https://github.com/technomancy/leiningen/blob/master/doc/DEPLOY.md#full-disk-encryption

The preferred approach is using a GPG-encrypted file, but this approach dramatically complicates use with Docker. This plain-text approach is simpler but does have some security implications, of course. However, given that we're all using full-disk encryption anyway (I hope) and the credential we're storing is (ideally) tied to a Datomic-Pro-Starter license rather than an account where a real Datomic purchase was made, it seems acceptable.

The `./.lein_profiles.clj` profile file could also be a hard-link (symlinks don't work unfortunately) to `~/.lein/profiles.clj` so it's easy to share with local dev as well as other Docker builds using this pattern...